### PR TITLE
Fix Transformer Mask errors

### DIFF
--- a/seq2seq/layer.py
+++ b/seq2seq/layer.py
@@ -232,13 +232,15 @@ class TransformerDecoderLayer(Layer):
         self.feedforward_layernorm = LayerNormalization(name="feedforward_layernorm")
         self.dropout = Dropout(dropout, name="dropout")
 
-    def call(self, input_embedding, encoder_output, mask=None):
+    def call(self, input_embedding, encoder_output, encoder_mask=None, decoder_mask=None):
         # [BatchSize, SequenceLength, DimEmbedding]
-        attention_output = self.self_attention(input_embedding, input_embedding, input_embedding, mask)
+        attention_output = self.self_attention(input_embedding, input_embedding, input_embedding, decoder_mask)
         normalized_output = self.attention_layernorm(input_embedding + self.dropout(attention_output))
 
         # [BatchSize, SequenceLength, DimEmbedding]
-        attention_output = self.encoder_decoder_attention(normalized_output, encoder_output, encoder_output)
+        attention_output = self.encoder_decoder_attention(
+            normalized_output, encoder_output, encoder_output, encoder_mask
+        )
         normalized_output = self.encoder_decoder_layernorm(normalized_output + self.dropout(attention_output))
 
         # [BatchSize, SequenceLength, DimEmbedding]

--- a/seq2seq/model.py
+++ b/seq2seq/model.py
@@ -90,7 +90,7 @@ class TransformerSeq2Seq(tf.keras.Model):
         for encoder_layer in self.encoder:
             encoder_input = encoder_layer(encoder_input, encoder_attention_mask)
         for decoder_layer in self.decoder:
-            decoder_input = decoder_layer(decoder_input, encoder_input, decoder_attention_mask)
+            decoder_input = decoder_layer(decoder_input, encoder_input, encoder_attention_mask, decoder_attention_mask)
 
         # [BatchSize, VocabSize]
         output = self.dense(decoder_input[:, -1, :])

--- a/seq2seq/model.py
+++ b/seq2seq/model.py
@@ -73,8 +73,8 @@ class TransformerSeq2Seq(tf.keras.Model):
     def call(self, inputs: Tuple[tf.Tensor, tf.Tensor], training: Optional[bool] = None):
         if len(inputs) == 2:
             encoder_tokens, decoder_tokens = inputs
-            encoder_attention_mask = tf.cast(encoder_tokens == self.pad_id, tf.float32)
-            decoder_attention_mask = tf.cast(decoder_tokens == self.pad_id, tf.float32)
+            encoder_attention_mask = tf.expand_dims(tf.cast(encoder_tokens == self.pad_id, tf.float32), axis=1)
+            decoder_attention_mask = tf.expand_dims(tf.cast(decoder_tokens == self.pad_id, tf.float32), axis=1)
         else:
             encoder_tokens, decoder_tokens, encoder_attention_mask, decoder_attention_mask = inputs
 

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -76,7 +76,7 @@ def test_transformer_encoder_layer_shape():
     dropout = 0.1
 
     input_embedding = tf.random.normal((batch_size, sequence_length, dim_embedding))
-    attention_mask = tf.random.uniform((batch_size, sequence_length, sequence_length), 0, 2, tf.float32)
+    attention_mask = tf.random.uniform((batch_size, 1, sequence_length), 0, 2, tf.float32)
     encoder_layer = TransformerEncoderLayer(dim_embedding, num_heads, dim_feedforward, dropout)
 
     output = encoder_layer(input_embedding, attention_mask)
@@ -85,19 +85,19 @@ def test_transformer_encoder_layer_shape():
 
 def test_transformer_decoder_layer_shape():
     batch_size = 4
-    sequence_length = 33
+    source_sequence_length = 33
+    target_sequence_length = 20
     encoder_dim_embedding = 44
     dim_embedding = 48
     num_heads = 2
     dim_feedforward = 128
     dropout = 0.1
 
-    inputs = (
-        tf.random.normal((batch_size, sequence_length, dim_embedding)),
-        tf.random.normal((batch_size, sequence_length, encoder_dim_embedding)),
-        tf.random.uniform((batch_size, sequence_length, sequence_length), 0, 2, tf.float32),
-    )
+    input_embedding = tf.random.normal((batch_size, target_sequence_length, dim_embedding))
+    encoder_output = tf.random.normal((batch_size, source_sequence_length, encoder_dim_embedding))
+    encoder_mask = tf.random.uniform((batch_size, 1, source_sequence_length), 0, 2, tf.float32)
+    decoder_mask = tf.random.uniform((batch_size, 1, target_sequence_length), 0, 2, tf.float32)
     decoder_layer = TransformerDecoderLayer(dim_embedding, num_heads, dim_feedforward, dropout)
 
-    output = decoder_layer(*inputs)
-    tf.debugging.assert_equal(tf.shape(output), [batch_size, sequence_length, dim_embedding])
+    output = decoder_layer(input_embedding, encoder_output, encoder_mask, decoder_mask)
+    tf.debugging.assert_equal(tf.shape(output), [batch_size, target_sequence_length, dim_embedding])

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -76,7 +76,7 @@ def test_transformer_encoder_layer_shape():
     dropout = 0.1
 
     input_embedding = tf.random.normal((batch_size, sequence_length, dim_embedding))
-    attention_mask = tf.random.uniform((batch_size, sequence_length), 0, 2, tf.float32)
+    attention_mask = tf.random.uniform((batch_size, sequence_length, sequence_length), 0, 2, tf.float32)
     encoder_layer = TransformerEncoderLayer(dim_embedding, num_heads, dim_feedforward, dropout)
 
     output = encoder_layer(input_embedding, attention_mask)
@@ -95,7 +95,7 @@ def test_transformer_decoder_layer_shape():
     inputs = (
         tf.random.normal((batch_size, sequence_length, dim_embedding)),
         tf.random.normal((batch_size, sequence_length, encoder_dim_embedding)),
-        tf.random.uniform((batch_size, sequence_length), 0, 2, tf.float32),
+        tf.random.uniform((batch_size, sequence_length, sequence_length), 0, 2, tf.float32),
     )
     decoder_layer = TransformerDecoderLayer(dim_embedding, num_heads, dim_feedforward, dropout)
 


### PR DESCRIPTION
Solve #13. 
There were bugs in generating mask. 
Fix mask generation logic. 
Fix to use mask with encoder-decoder attention in Transformer Decoder Layer too.
Update tests.